### PR TITLE
Change arrayToCSV to use Array.toList() on each row instead of an inner row item loop

### DIFF
--- a/CSV.cfc
+++ b/CSV.cfc
@@ -186,27 +186,33 @@ component {
 	// arrayToCSV takes an array of arrays where each outer array item is an array representing a row of data that should be printed in a CSV document
 	// Using java.lang.StringBuffer over Coldfusion's array concatenation is about 10 times faster
 	// Using Java Iterators is about 10% faster than accessing the arrays using Coldfusion's for loops
+
+	// Previous version with item loops does 100k rows in 19.888 seconds
+	// Version with hacky toList does 100k rows in 18.406 seconds
 	public string function arrayToCSV(required array arr, array header = []) {
 		var csvText = createObject("java", "java.lang.StringBuffer");
 
 		// Build header if needed
 		if (header.len() > 0) {
-			var headerIter = header.Iterator();
+			// Instead of looping over each header label to add qualifiers, just convert to string with the qualifiers and comma as the separator
+			csvText.append(JavaCast("string", variables.tempQualifier & header.toList("#variables.tempQualifier#,#variables.tempQualifier#") & variables.tempQualifier & newline);
 
-			while (headerIter.hasNext()) {
-				var heading = headerIter.next();
-
-				// Each heading is qualified inside of double quotes
-				csvText.append(JavaCast("string", variables.tempQualifier & heading & variables.tempQualifier));
-
-				// Comma separated values in the header row
-				if (headerIter.hasNext()) {
-					csvText.append(",");
-				}
-			}
-
-			// Newline after header
-			csvText.append(newline);
+			// var headerIter = header.Iterator();
+			//
+			// while (headerIter.hasNext()) {
+			// 	var heading = headerIter.next();
+			//
+			// 	// Each heading is qualified inside of double quotes
+			// 	csvText.append(JavaCast("string", variables.tempQualifier & heading & variables.tempQualifier));
+			//
+			// 	// Comma separated values in the header row
+			// 	if (headerIter.hasNext()) {
+			// 		csvText.append(",");
+			// 	}
+			// }
+			//
+			// // Newline after header
+			// csvText.append(newline);
 		}
 
 		// Each row
@@ -215,22 +221,25 @@ component {
 		while (arrIter.hasNext()) {
 			// Get the row array
 			var row = arrIter.next();
-			var rowIter = row.Iterator();
+			// var rowIter = row.Iterator();
 
-			while (rowIter.hasNext()) {
-				var item = rowIter.next();
+			// Instead of looping over each header label to add qualifiers, just convert to string with the qualifiers and comma as the separator
+			csvText.append(JavaCast("string", variables.tempQualifier & row.toList("#variables.tempQualifier#,#variables.tempQualifier#") & variables.tempQualifier & newline);
 
-				// Each row item is qualified inside of double quotes
-				csvText.append(JavaCast("string", variables.tempQualifier & item & variables.tempQualifier));
-
-				// Comma separated values in each data row
-				if (rowIter.hasNext()) {
-					csvText.append(",");
-				}
-			}
-
-			// Newline after each row
-			csvText.append(newline);
+			// while (rowIter.hasNext()) {
+			// 	var item = rowIter.next();
+			//
+			// 	// Each row item is qualified inside of double quotes
+			// 	csvText.append(JavaCast("string", variables.tempQualifier & item & variables.tempQualifier));
+			//
+			// 	// Comma separated values in each data row
+			// 	if (rowIter.hasNext()) {
+			// 		csvText.append(",");
+			// 	}
+			// }
+			//
+			// // Newline after each row
+			// csvText.append(newline);
 		}
 
 		// Waiting until the very end to escape quotes and add qualifier quotes speeds this up by more than double
@@ -289,7 +298,7 @@ component {
 
 		return escapedCSV;
 	}
-	
+
 	private string function escapeCSV(required string csv) {
 		// Escape double quotes
 		csv = replace(csv, """", """""", "all");

--- a/CSV.cfc
+++ b/CSV.cfc
@@ -187,8 +187,10 @@ component {
 	// Using java.lang.StringBuffer over Coldfusion's array concatenation is about 10 times faster
 	// Using Java Iterators is about 10% faster than accessing the arrays using Coldfusion's for loops
 
-	// Previous version with item loops does 100k rows in 19.888 seconds
-	// Version with hacky toList does 100k rows in 18.406 seconds
+	// Note about switching from a loop for each row item to using toList():
+	// Removing this inner loop significantly speeds up CSV creation
+	// Previous version with item loops did 100k rows with 20 columns in 40 seconds
+	// Version with hacky toList does the same 100k rows with 20 columns in 3.788 seconds
 	public string function arrayToCSV(required array arr, array header = []) {
 		var csvText = createObject("java", "java.lang.StringBuffer");
 
@@ -196,23 +198,6 @@ component {
 		if (header.len() > 0) {
 			// Instead of looping over each header label to add qualifiers, just convert to string with the qualifiers and comma as the separator
 			csvText.append(JavaCast("string", variables.tempQualifier & header.toList("#variables.tempQualifier#,#variables.tempQualifier#") & variables.tempQualifier & newline));
-
-			// var headerIter = header.Iterator();
-			//
-			// while (headerIter.hasNext()) {
-			// 	var heading = headerIter.next();
-			//
-			// 	// Each heading is qualified inside of double quotes
-			// 	csvText.append(JavaCast("string", variables.tempQualifier & heading & variables.tempQualifier));
-			//
-			// 	// Comma separated values in the header row
-			// 	if (headerIter.hasNext()) {
-			// 		csvText.append(",");
-			// 	}
-			// }
-			//
-			// // Newline after header
-			// csvText.append(newline);
 		}
 
 		// Each row
@@ -221,25 +206,9 @@ component {
 		while (arrIter.hasNext()) {
 			// Get the row array
 			var row = arrIter.next();
-			// var rowIter = row.Iterator();
 
 			// Instead of looping over each header label to add qualifiers, just convert to string with the qualifiers and comma as the separator
 			csvText.append(JavaCast("string", variables.tempQualifier & row.toList("#variables.tempQualifier#,#variables.tempQualifier#") & variables.tempQualifier & newline));
-
-			// while (rowIter.hasNext()) {
-			// 	var item = rowIter.next();
-			//
-			// 	// Each row item is qualified inside of double quotes
-			// 	csvText.append(JavaCast("string", variables.tempQualifier & item & variables.tempQualifier));
-			//
-			// 	// Comma separated values in each data row
-			// 	if (rowIter.hasNext()) {
-			// 		csvText.append(",");
-			// 	}
-			// }
-			//
-			// // Newline after each row
-			// csvText.append(newline);
 		}
 
 		// Waiting until the very end to escape quotes and add qualifier quotes speeds this up by more than double

--- a/CSV.cfc
+++ b/CSV.cfc
@@ -195,7 +195,7 @@ component {
 		// Build header if needed
 		if (header.len() > 0) {
 			// Instead of looping over each header label to add qualifiers, just convert to string with the qualifiers and comma as the separator
-			csvText.append(JavaCast("string", variables.tempQualifier & header.toList("#variables.tempQualifier#,#variables.tempQualifier#") & variables.tempQualifier & newline);
+			csvText.append(JavaCast("string", variables.tempQualifier & header.toList("#variables.tempQualifier#,#variables.tempQualifier#") & variables.tempQualifier & newline));
 
 			// var headerIter = header.Iterator();
 			//
@@ -224,7 +224,7 @@ component {
 			// var rowIter = row.Iterator();
 
 			// Instead of looping over each header label to add qualifiers, just convert to string with the qualifiers and comma as the separator
-			csvText.append(JavaCast("string", variables.tempQualifier & row.toList("#variables.tempQualifier#,#variables.tempQualifier#") & variables.tempQualifier & newline);
+			csvText.append(JavaCast("string", variables.tempQualifier & row.toList("#variables.tempQualifier#,#variables.tempQualifier#") & variables.tempQualifier & newline));
 
 			// while (rowIter.hasNext()) {
 			// 	var item = rowIter.next();


### PR DESCRIPTION
Using a hacky delimiter of the column value qualifier, a comma and another column value qualifier is an order of magnitude faster than looping over each item and wrapping it in qualifiers (double quotes eventually)